### PR TITLE
fix: usage for js

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ yarn add @zeit-ui/themes
 
 ### Import
 
-  - In `.js` file: `import '@zeit-ui/themes/index'`
+  - In `.js` file: `import '@zeit-ui/themes/index.css'`
   
   - Or `.(css|stylus|styl|scss|sass)` file: `@import '~@zeit-ui/themes/index.css'`
 


### PR DESCRIPTION
import `index.js` 无法正确引入样式（因为 css 被 extract 了，js 中没有任何相关信息）